### PR TITLE
fix(web): resolve auth routing and state loading issues

### DIFF
--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -41,6 +41,14 @@ function PageLoader() {
   return <LoadingState className="min-h-[40vh]" compact />
 }
 
+function FullScreenLoader() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+    </div>
+  )
+}
+
 function LazyPage({ children }: { children: ReactNode }) {
   return <Suspense fallback={<PageLoader />}>{children}</Suspense>
 }
@@ -48,11 +56,7 @@ function LazyPage({ children }: { children: ReactNode }) {
 function RequireAuth() {
   const { isAuthenticated, isLoading } = useAuth()
   if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-      </div>
-    )
+    return <FullScreenLoader />
   }
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />
@@ -63,16 +67,43 @@ function RequireAuth() {
 function RequireAdmin() {
   const { user, isLoading } = useAuth()
   if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-      </div>
-    )
+    return <FullScreenLoader />
   }
   if (user?.role !== 'admin') {
     return <Navigate to="/console" replace />
   }
   return <Outlet />
+}
+
+function RequireGuest() {
+  const { isAuthenticated, isLoading } = useAuth()
+  if (isLoading) {
+    return <FullScreenLoader />
+  }
+  if (isAuthenticated) {
+    return <Navigate to="/console/upload" replace />
+  }
+  return <Outlet />
+}
+
+function HomeRoute({ config }: { config: SiteConfig | undefined }) {
+  const { isAuthenticated, isLoading } = useAuth()
+
+  if (isLoading) {
+    return <FullScreenLoader />
+  }
+
+  if (isAuthenticated) {
+    return <Navigate to="/console/upload" replace />
+  }
+
+  return config?.allow_guest_upload ? (
+    <LazyPage>
+      <GuestUploadPage />
+    </LazyPage>
+  ) : (
+    <Navigate to="/login" replace />
+  )
 }
 
 function PublicRoutes() {
@@ -83,11 +114,7 @@ function PublicRoutes() {
   })
 
   if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-      </div>
-    )
+    return <FullScreenLoader />
   }
 
   if (config?.setup_required) {
@@ -117,32 +144,26 @@ function PublicRoutes() {
           <Route element={<PublicLayout />}>
             <Route
               path="/"
-              element={
-                config?.allow_guest_upload ? (
-                  <LazyPage>
-                    <GuestUploadPage />
-                  </LazyPage>
-                ) : (
-                  <Navigate to="/login" replace />
-                )
-              }
+              element={<HomeRoute config={config} />}
             />
-            <Route path="/login" element={<LazyPage><LoginPage /></LazyPage>} />
-            <Route path="/forgot-password" element={<LazyPage><ForgotPasswordPage /></LazyPage>} />
             <Route path="/reset-password" element={<LazyPage><ResetPasswordPage /></LazyPage>} />
             <Route path="/verify-email" element={<LazyPage><VerifyEmailPage /></LazyPage>} />
-            <Route
-              path="/register"
-              element={
-                config?.allow_registration ? (
-                  <LazyPage>
-                    <RegisterPage />
-                  </LazyPage>
-                ) : (
-                  <Navigate to="/login" replace />
-                )
-              }
-            />
+            <Route element={<RequireGuest />}>
+              <Route path="/login" element={<LazyPage><LoginPage /></LazyPage>} />
+              <Route path="/forgot-password" element={<LazyPage><ForgotPasswordPage /></LazyPage>} />
+              <Route
+                path="/register"
+                element={
+                  config?.allow_registration ? (
+                    <LazyPage>
+                      <RegisterPage />
+                    </LazyPage>
+                  ) : (
+                    <Navigate to="/login" replace />
+                  )
+                }
+              />
+            </Route>
           </Route>
 
           <Route element={<RequireAuth />}>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -57,7 +57,10 @@ api.interceptors.response.use(
   (res) => res,
   async (err) => {
     const originalRequest = err.config
-    const isAuthEndpoint = originalRequest?.url?.startsWith('/auth/login') || originalRequest?.url?.startsWith('/auth/register')
+    const isAuthEndpoint =
+      originalRequest?.url?.startsWith('/auth/login') ||
+      originalRequest?.url?.startsWith('/auth/register') ||
+      originalRequest?.url?.startsWith('/auth/refresh')
     if (err.response?.status === 401 && originalRequest && !originalRequest._retry && !isAuthEndpoint) {
       const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY)
 

--- a/web/src/lib/auth-context.tsx
+++ b/web/src/lib/auth-context.tsx
@@ -17,17 +17,23 @@ const AuthContext = createContext<AuthContextValue | null>(null)
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<UserProfile | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
     let mounted = true
     const fetchProfile = async () => {
       setIsLoading(true)
       try {
+        if (!authApi.hasToken()) {
+          const tokens = await authApi.refreshTokens()
+          authApi.saveTokens(tokens)
+        }
         const profile = await authApi.getProfile()
         if (mounted) setUser(profile)
       } catch (err: unknown) {
-        logError('auth.fetchProfile', err)
+        if (authApi.hasToken()) {
+          logError('auth.fetchProfile', err)
+        }
         if (authApi.hasToken()) {
           authApi.clearTokens()
         }
@@ -41,25 +47,34 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [])
 
   const login = useCallback(async (email: string, password: string) => {
-    const tokens = await authApi.login(email, password)
-    authApi.saveTokens(tokens)
-    const profile = await authApi.getProfile()
-    setUser(profile)
+    setIsLoading(true)
+    try {
+      const tokens = await authApi.login(email, password)
+      authApi.saveTokens(tokens)
+      const profile = await authApi.getProfile()
+      setUser(profile)
+    } finally {
+      setIsLoading(false)
+    }
   }, [])
 
   const register = useCallback(async (email: string, password: string, name: string, language?: string) => {
-    const result = await authApi.register(email, password, name, language)
-    if (result.tokens) {
-      authApi.saveTokens(result.tokens)
-      const profile = await authApi.getProfile()
-      setUser(profile)
-    } else {
-      authApi.clearTokens()
-      setUser(null)
+    setIsLoading(true)
+    try {
+      const result = await authApi.register(email, password, name, language)
+      if (result.tokens) {
+        authApi.saveTokens(result.tokens)
+        const profile = await authApi.getProfile()
+        setUser(profile)
+      } else {
+        authApi.clearTokens()
+        setUser(null)
+      }
+      return result
+    } finally {
+      setIsLoading(false)
     }
-    return result
   }, [])
-
   const logout = useCallback(async () => {
     await authApi.logout()
     authApi.clearTokens()

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -91,6 +91,11 @@ export async function logout(): Promise<void> {
   }
 }
 
+export async function refreshTokens(): Promise<AuthTokens> {
+  const res = await api.post<ApiResponse<AuthTokens>>('/auth/refresh')
+  return res.data.data
+}
+
 export async function getProfile(): Promise<UserProfile> {
   const res = await api.get<ApiResponse<UserProfile>>('/users/me')
   return res.data.data


### PR DESCRIPTION
## Summary

- 优先使用登录态处理根路径 `/` 的跳转逻辑，已登录用户始终进入 `/console/upload` 
- 已登录用户不再可访问 `/login` 和 `/register`

## Impact

- 已登录用户访问 `/` 不会再被错误跳转到 `/login`
- 未登录用户仍按游客上传开关决定展示游客页或跳转登录页

## Validation

- 已成功构建 Docker 镜像并完成手动验证
- 已确认登录用户访问 `/` 会跳转到 `/console/upload` 且不再可访问 `/login` 和 `/register`
